### PR TITLE
fix(searchResults): only enable personalization if non empty persona

### DIFF
--- a/html/categoryPageAccessories.html
+++ b/html/categoryPageAccessories.html
@@ -61,6 +61,7 @@
             <p class="closePersona">x</p>
             <p>Choose a Persona</p>
             <select id="user-token-selector" class="user-token-selector">
+                <option value="">none</option>
                 <option value="woman">woman</option>
                 <option value="man">man</option>
             </select>

--- a/html/categoryPageJeans.html
+++ b/html/categoryPageJeans.html
@@ -68,6 +68,7 @@
             <p class="closePersona">x</p>
             <p>Choose a Persona</p>
             <select id="user-token-selector" class="user-token-selector">
+                <option value="">none</option>
                 <option value="woman">woman</option>
                 <option value="man">man</option>
             </select>

--- a/src/SearchResultPage/searchResults.js
+++ b/src/SearchResultPage/searchResults.js
@@ -305,6 +305,7 @@ export function searchResults() {
         userToken: e.target.value,
         ruleContexts: [e.target.value],
         filters: extraSearchFilters,
+        enablePersonalization: e.target.value !== '' ? true : false,
       });
     });
   };
@@ -489,7 +490,7 @@ export function searchResults() {
       container: document.querySelector('#configure'),
       searchParameters: {
         hitsPerPage: 20,
-        enablePersonalization: true,
+        enablePersonalization: false,
         filters: extraSearchFilters,
         query: localStorage.getItem('userQuery')
           ? localStorage.getItem('userQuery')


### PR DESCRIPTION

Please check if the PR fulfills these requirements
 The commit message follows our guidelines YES
 Tests for the changes have been added (for bug fixes / features) NA
 Docs have been added / updated (for bug fixes / features) NA
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...) NA

What is the current behavior? (You can also link to an open issue here)
Personalization always enabled, preventing re-ranking from applying

What is the new behavior (if this is a feature change)?
By default re-ranking now applies on the jeans page and accessories page

Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
NO